### PR TITLE
feat(insights): supporting unpaired wrapping chars #10

### DIFF
--- a/archguard/src/pages/insights/searchbar/lang/lexer.test.ts
+++ b/archguard/src/pages/insights/searchbar/lang/lexer.test.ts
@@ -21,6 +21,11 @@ test("normal dsl", async () => {
   ].forEach((expected, index) => expect(tokens[index]).toEqual(expected));
 });
 
+test("unpaired wrapper", async () => {
+  let tokens = lexer(`field:dep_name = '"\`/%`);
+  expect(tokens.length).toBe(9);
+});
+
 test("string value", async () => {
   let tokens = lexer(`field:dep_name 'log4j'`);
 

--- a/archguard/src/pages/insights/searchbar/lang/lexer.ts
+++ b/archguard/src/pages/insights/searchbar/lang/lexer.ts
@@ -205,10 +205,9 @@ export function lexer(text: string) {
           current++;
         }
 
-        current++;
-
-        if (value != "" + char) {
+        if (text[current + 1] === endChar) {
           // move to endChar
+          current++;
           value += text[current];
 
           tokens.push({
@@ -217,6 +216,14 @@ export function lexer(text: string) {
             start: startPos,
             end: ++current,
           } as ValueToken);
+        } else {
+          current = startPos;
+          tokens.push({
+            type: "error",
+            value: endChar,
+            start: startPos,
+            end: ++current,
+          });
         }
 
         break;


### PR DESCRIPTION
...Plus renaming `literal.test.ts` to `lexer.test.ts` to conformant commit 2e81d96dfeaec191549020acc2f3f89b5dfe1e79